### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -21,7 +21,6 @@ jobs:
           FUSEKI_DATASET_1: /ontogen-test-dataset
         options: >-
           --name fuseki
-          --entrypoint "/bin/sh"
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -21,6 +21,7 @@ jobs:
           FUSEKI_DATASET_1: /ontogen-test-dataset
         options: >-
           --name fuseki
+          --entrypoint "/bin/sh"
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Create and copy shiro.ini, then restart Fuseki
+      - name: Start Fuseki with custom configuration
         run: |
           echo "
           ## Minimal configuration without auth from https://jena.apache.org/documentation/fuseki2/fuseki-security.html
@@ -55,9 +56,7 @@ jobs:
           /$/** = localhost
           /**=anon
           " > shiro.ini
-          docker cp shiro.ini fuseki:/fuseki/shiro.ini
-          docker exec fuseki ls -l /fuseki/shiro.ini
-          docker restart fuseki
+          docker exec fuseki sh -c "cp /github-workspace/shiro.ini /fuseki/shiro.ini && /docker-entrypoint.sh"
           timeout 30s bash -c 'until curl -s -f -o /dev/null http://localhost:3030/$/ping; do echo "Waiting for Fuseki..."; sleep 2; done'
 
       - name: Copy shiro.ini to Fuseki container

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -19,9 +19,7 @@ jobs:
           - 3030:3030
         env:
           FUSEKI_DATASET_1: /ontogen-test-dataset
-        options: >-
-          --name fuseki
-          --entrypoint "/bin/sh"
+        options: --name fuseki
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +38,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Start Fuseki with custom configuration
+      - name: Create and copy shiro.ini, then restart Fuseki
         run: |
           echo "
           ## Minimal configuration without auth from https://jena.apache.org/documentation/fuseki2/fuseki-security.html
@@ -56,13 +54,10 @@ jobs:
           /$/** = localhost
           /**=anon
           " > shiro.ini
-          docker exec fuseki sh -c "cp /github-workspace/shiro.ini /fuseki/shiro.ini && /docker-entrypoint.sh"
-          timeout 30s bash -c 'until curl -s -f -o /dev/null http://localhost:3030/$/ping; do echo "Waiting for Fuseki..."; sleep 2; done'
-
-      - name: Copy shiro.ini to Fuseki container
-        run: |
           docker cp shiro.ini fuseki:/fuseki/shiro.ini
           docker exec fuseki ls -l /fuseki/shiro.ini
+          docker restart fuseki
+          timeout 30s bash -c 'until curl -s -f -o /dev/null http://localhost:3030/$/ping; do echo "Waiting for Fuseki..."; sleep 2; done'
 
       - name: Setup Elixir Project
         uses: ./.github/actions/elixir-setup

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -19,7 +19,9 @@ jobs:
           - 3030:3030
         env:
           FUSEKI_DATASET_1: /ontogen-test-dataset
-        options: --name fuseki
+        options: >-
+          --name fuseki
+          --entrypoint "/bin/sh"
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Create shiro.ini
+      - name: Create and copy shiro.ini, then restart Fuseki
         run: |
           echo "
           ## Minimal configuration without auth from https://jena.apache.org/documentation/fuseki2/fuseki-security.html
@@ -54,6 +56,10 @@ jobs:
           /$/** = localhost
           /**=anon
           " > shiro.ini
+          docker cp shiro.ini fuseki:/fuseki/shiro.ini
+          docker exec fuseki ls -l /fuseki/shiro.ini
+          docker restart fuseki
+          timeout 30s bash -c 'until curl -s -f -o /dev/null http://localhost:3030/$/ping; do echo "Waiting for Fuseki..."; sleep 2; done'
 
       - name: Copy shiro.ini to Fuseki container
         run: |


### PR DESCRIPTION
This restarts Fuseki after the shiro config was created, since the [docs](https://jena.apache.org/documentation/fuseki2/fuseki-security.html) clearly say, that this is required. Not sure, why this worked previously without a restart (and exactly the same setup without a restart in the core repo also).  🤷🏻